### PR TITLE
Explicitly copy static files to the `static-files` volume at start up

### DIFF
--- a/indico-prod/docker-compose.yml
+++ b/indico-prod/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - 'archive:/opt/indico/archive' # file storage
       - 'customization:/opt/indico/custom'
-      - 'static-files:/opt/indico/static'
+      - 'static-files:/opt/indico/static-shared'
       - 'indico-logs:/opt/indico/log' # logs
       - type: bind
         source: ${INDICO_CONFIG}

--- a/indico-prod/worker/Dockerfile
+++ b/indico-prod/worker/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex && \
 
 RUN set -ex && \
     apt-get update && \
-    apt-get -y install texlive-xetex libpq-dev postgresql-client vim less gcc gettext libldap2-dev && \
+    apt-get -y install texlive-xetex libpq-dev postgresql-client vim less gcc gettext libldap2-dev rsync && \
     apt-get clean
 
 COPY uwsgi.ini /etc/uwsgi.ini
@@ -26,6 +26,7 @@ RUN set -ex && \
     mkdir -p --mode=750 /opt/indico/log && \
     mkdir -p --mode=750 /opt/indico/cache && \
     mkdir -p --mode=750 /opt/indico/archive && \
+    mkdir -p --mode=750 /opt/indico/static-shared && \
     chown -R indico:indico /opt/indico
 
 # XXX do we still need this?

--- a/indico-prod/worker/run_indico.sh
+++ b/indico-prod/worker/run_indico.sh
@@ -4,6 +4,9 @@ connect_to_db() {
     psql -lqt | cut -d \| -f 1 | grep -qw $PGDATABASE
 }
 
+echo "Copying static files to a shared volume..."
+rsync --archive --delete /opt/indico/static/ /opt/indico/static-shared/
+
 # Wait until the DB becomes available
 until connect_to_db; do
     echo "Waiting for DB to become available..."


### PR DESCRIPTION
I _think_ this fixes #73 but some testing would be appreciated. 

I wasn't able to make the copying conditional as suggested in the issue due problems with permissions. When you mount a volume to a new directory, the owner is set to root, which the prevents the Docker entrypoint (`run_indico.sh`) from cp-ing/rsyncing the files as the script runs as `indico`.

Instead I just create the folder in the image (`/opt/indico/static-shared`). This way I can set the correct owner ahead of time, so that I can rsync it in the Docker entrypoint.

@defnull could you confirm that this fixes the issue for you?