### PR TITLE
Fix indico uid back to 999

### DIFF
--- a/indico-prod/worker/Dockerfile
+++ b/indico-prod/worker/Dockerfile
@@ -10,13 +10,14 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 USER root
 
 RUN set -ex && \
+    groupadd -r -g 999 indico && \
+    useradd -r -u 999 -g indico -m -d /opt/indico indico && \
+    usermod indico --add-subuids 1000000-1065535 --add-subgids 1000000-1065535
+
+RUN set -ex && \
     apt-get update && \
     apt-get -y install libpq-dev postgresql-client vim less gcc gettext libldap2-dev rsync podman && \
     apt-get clean
-
-RUN set -ex && \
-    groupadd -r indico && \
-    useradd -r -g indico -m -d /opt/indico --add-subids-for-system indico
 
 COPY uwsgi.ini /etc/uwsgi.ini
 WORKDIR /opt/indico


### PR DESCRIPTION
See [this forum thread](https://talk.getindico.io/t/venv-issue-access-with-when-using-docker-image-indico-v3-3-10-and-above/4513?u=thiefmaster) for details.

By creating the indico user after installing packages, uid `999` was already taken, so the next free uid (`995`) got assigned.

We now always set `999` (which will conveniently make the build fail if the ID is unavailable), and manually assign the subids (since adding them automatically seems to depend on one of the packages we install later).