### PR TITLE
FIX: Propagate SIGTERM to uwsgi and terminate

### DIFF
--- a/indico-prod/worker/run_indico.sh
+++ b/indico-prod/worker/run_indico.sh
@@ -34,4 +34,4 @@ else
 fi
 
 echo 'Starting Indico...'
-uwsgi /etc/uwsgi.ini
+exec uwsgi /etc/uwsgi.ini

--- a/indico-prod/worker/uwsgi.ini
+++ b/indico-prod/worker/uwsgi.ini
@@ -25,6 +25,7 @@ virtualenv = /opt/indico/.venv
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true
+die-on-term = true
 
 vacuum = true
 memory-report = true


### PR DESCRIPTION
BREAKING: SIGTERM may no longer be used for brutal reload (SIGHUP is unaffected) _But honestly, if any of you were using SIGTERM for brutal reloads you kinda deserved it_

This changeset addresses #93.
The docker and kubernetes stop commands now work as expected.

The exec change ensures that PID 1 in the container is now correctly the uwsgi master process. Indeed, we can see this behavior in action.

Before:

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
indico       1  0.0  0.0   4488  3432 ?        Ss   10:00   0:00 /bin/bash /opt/indico/run_indico.sh
indico      83  1.0  1.7 315484 272824 ?       S    10:00   0:02 indico uWSGI master
indico     140  0.0  1.5 727172 241704 ?       Sl   10:00   0:00 indico uWSGI worker 1
indico     146  0.0  1.5 728352 242920 ?       Sl   10:00   0:00 indico uWSGI worker 2
indico     152  0.1  1.6 737608 258944 ?       Sl   10:00   0:00 indico uWSGI worker 3
indico     158  0.1  1.7 750416 272420 ?       Sl   10:00   0:00 indico uWSGI worker 4
indico     170  0.0  0.0   2672  1108 pts/0    Ss+  10:03   0:00 /bin/sh
indico     182  0.0  0.0   4752  4144 pts/1    Ss   10:04   0:00 bash
indico     192  0.0  0.0   7192  4216 pts/1    R+   10:05   0:00 ps -aux
```

After:

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
indico       1 32.0  1.8 331808 290140 ?       Ss   10:47   0:05 indico uWSGI master
indico      74  0.0  1.6 669748 255804 ?       Sl   10:47   0:00 indico uWSGI worker 1
indico      80  0.0  1.6 669748 255804 ?       Sl   10:47   0:00 indico uWSGI worker 2
indico      86  0.0  1.6 669748 255804 ?       Sl   10:47   0:00 indico uWSGI worker 3
indico      92  0.0  1.6 669748 255804 ?       Sl   10:47   0:00 indico uWSGI worker 4
indico      98  0.0  0.0   4752  3976 pts/0    Ss   10:47   0:00 bash
indico     106  0.0  0.0   7192  4244 pts/0    R+   10:47   0:00 ps -aux
```

The uwsgi change ensures that SIGTERM will actually terminate rather than brutally reload. SIGHUP is unaffected by the change. Since SIGTERM is also the default used in docker stop and Kubernetes stop actions, we do not need to add a DOCKER_STOP_COMMAND flag either.

Before:

`kill -15 83` (from inside the container)

```
indico-nginx-1        | 2026/05/31 10:09:16 [info] 21#21: *51 epoll_wait() reported that client prematurely closed connection, so upstream connection is closed too while sending request to upstream, client: 172.18.0.1, server: , request: "GET / HTTP/1.1", upstream: "http://172.18.0.2:59999/", host: "localhost:8080", referrer: "http://localhost:8080/"
indico-nginx-1        | 172.18.0.1 - - [31/May/2026:10:09:16 +0000] "GET / HTTP/1.1" 499 0 "http://localhost:8080/" "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
indico-web-1          | WSGI app 0 (mountpoint='') ready in 3 seconds on interpreter 0x7fbdc3272390 pid: 83 (default app)
indico-web-1          | gracefully (RE)spawned uWSGI master process (pid: 83)
indico-web-1          | spawned uWSGI worker 1 (pid: 250, cores: 1)
indico-web-1          | Sun May 31 10:09:17 2026 - mem-collector thread started for worker 1
indico-web-1          | spawned 4 offload threads for uWSGI worker 1
indico-web-1          | spawned uWSGI worker 2 (pid: 256, cores: 1)
indico-web-1          | Sun May 31 10:09:17 2026 - mem-collector thread started for worker 2
indico-web-1          | spawned 4 offload threads for uWSGI worker 2
indico-web-1          | spawned uWSGI worker 3 (pid: 262, cores: 1)
indico-web-1          | Sun May 31 10:09:17 2026 - mem-collector thread started for worker 3
indico-web-1          | spawned 4 offload threads for uWSGI worker 3
indico-web-1          | spawned uWSGI worker 4 (pid: 268, cores: 1)
indico-web-1          | spawned 4 offload threads for uWSGI worker 4
indico-web-1          | Sun May 31 10:09:17 2026 - mem-collector thread started for worker 4
```

After:
`kill -15 1` (from inside the container)

```
indico-web-1          | SIGINT/SIGTERM received...killing workers...
indico-web-1          | worker 1 buried after 2 seconds
indico-web-1          | worker 2 buried after 2 seconds
indico-web-1          | worker 3 buried after 2 seconds
indico-web-1          | worker 4 buried after 2 seconds
indico-web-1          | goodbye to uWSGI.
indico-web-1 exited with code 0
```